### PR TITLE
v8.1.2：修复设备只读状态异常与规格拉取失败 (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## [v8.1.2] - 2026-08-03
+
+### 修复
+
+- 修复 v8.1.0 起三台设备（lemesh.light.wy0c02 / xiaomi.wifispeaker.l7a / yeelink.light.mono5）只读状态异常：共享设备列表兜底容错、DevProp/DevAction 构造跳过异常属性/动作，避免 KeyError 打断状态读取。
+- 规格拉取改用独立解析并回退 i18n 语言表（zh_cn -> en -> 空），修复 yeelink.light.mono5 等型号因缺少 i18n 文案导致规格拉取失败、只读状态报 MiHomeClientError 的问题。
+- 设备状态读取对 KeyError 与“云端查无此设备”输出明确诊断文案，不再暴露原始异常名。
+
 ## [v8.1.1] - 2026-07-24
 
 ### 修复

--- a/_spec_worker.py
+++ b/_spec_worker.py
@@ -1,13 +1,170 @@
 # -*- coding: utf-8 -*-
+"""在可终止子进程中拉取并校验公开设备规格，输出与 mijiaAPI 兼容的 schema。"""
+
 import json
 import re
 import sys
 from pathlib import Path
 
-from mijiaAPI import get_device_info
+import requests
 
 
 MODEL_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,159}")
+SPEC_URL_TEMPLATE = "https://home.miot-spec.com/spec/{model}"
+APP_JSON_PATTERN = re.compile(
+    r'<script data-page="app" type="application/json">(.*?)</script>',
+    re.DOTALL,
+)
+SPEC_FETCH_TIMEOUT = 20.0
+
+# 与 mijiaAPI DevProp 支持的类型保持一致；其余格式直接跳过，
+# 避免“未知类型”让整台设备的只读能力被废弃。
+_SUPPORTED_TYPES = {"bool", "int", "uint", "float", "string"}
+
+
+def _lookup_i18n(i18n: dict, key: str) -> str:
+    """按 zh_cn → en → 空串的顺序取本地化文案。
+
+    上游 mijiaAPI 对 ``props.i18n.zh_cn`` 使用硬下标，而部分型号
+    （如 yeelink.light.mono5）只有 en 语言表，直接导致
+    ``KeyError: 'zh_cn'``。这里做语言回退以兼容这些型号。
+    """
+
+    if not isinstance(i18n, dict):
+        return ""
+    for lang in ("zh_cn", "en"):
+        table = i18n.get(lang)
+        if not isinstance(table, dict):
+            continue
+        text = str(table.get(key, "") or "").strip()
+        if text:
+            return text
+    return ""
+
+
+def fetch_device_spec(model: str) -> dict:
+    """拉取 miot-spec 页面并解析为插件消费的规格结构。"""
+
+    url = SPEC_URL_TEMPLATE.format(model=model)
+    response = requests.get(
+        url,
+        headers={"User-Agent": "mijiaAPI/4.1.3"},
+        timeout=SPEC_FETCH_TIMEOUT,
+    )
+    if response.status_code != 200:
+        raise ValueError(f"设备规格页面返回 {response.status_code}")
+    match = APP_JSON_PATTERN.search(response.text)
+    if match is None:
+        raise ValueError("设备规格页面缺少应用数据")
+    content = json.loads(match.group(1))
+
+    props = content.get("props") or {}
+    product = props.get("product") or {}
+    if not isinstance(product, dict) or not product.get("model"):
+        raise ValueError("设备规格结构异常")
+    i18n = props.get("i18n") or {}
+    services = (props.get("tree") or {}).get("services") or []
+    if not isinstance(services, list):
+        raise ValueError("设备规格结构异常")
+
+    result = {
+        "name": product.get("name") or model,
+        "model": product.get("model") or model,
+        "properties": [],
+        "actions": [],
+    }
+    properties_name = []
+    actions_name = []
+
+    for svc in services:
+        if not isinstance(svc, dict):
+            continue
+        siid = svc.get("iid")
+        if not isinstance(siid, int):
+            continue
+        svc_type = str(svc.get("type") or "")
+
+        for prop in svc.get("properties") or []:
+            if not isinstance(prop, dict):
+                continue
+            piid = prop.get("iid")
+            if not isinstance(piid, int):
+                continue
+            fmt = str(prop.get("format") or "")
+            if fmt.startswith("int"):
+                prop_type = "int"
+            elif fmt.startswith("uint"):
+                prop_type = "uint"
+            else:
+                prop_type = fmt
+            if prop_type not in _SUPPORTED_TYPES:
+                continue
+            access = prop.get("access") or []
+            access_str = "".join(
+                [
+                    "r" if "read" in access else "",
+                    "w" if "write" in access else "",
+                ]
+            )
+            zh_cn = _lookup_i18n(
+                i18n,
+                f"service:{siid:03d}:property:{piid:03d}",
+            )
+            item = {
+                "name": str(prop.get("type") or ""),
+                "description": f"{prop.get('description') or ''} / {zh_cn}".rstrip(
+                    " / "
+                ),
+                "type": prop_type,
+                "rw": access_str,
+                "range": prop.get("valueRange", None),
+                "value-list": None,
+                "method": {"siid": siid, "piid": piid},
+            }
+            if prop.get("valueList"):
+                item["value-list"] = []
+                for vl_item in prop["valueList"]:
+                    if not isinstance(vl_item, dict):
+                        continue
+                    vl_zh = _lookup_i18n(
+                        i18n,
+                        str(vl_item.get("i18nKey") or ""),
+                    )
+                    vl_entry = {
+                        "value": vl_item.get("value"),
+                        "description": str(vl_item.get("description") or ""),
+                    }
+                    if vl_zh:
+                        vl_entry["desc_zh_cn"] = vl_zh
+                    item["value-list"].append(vl_entry)
+            if item["name"] in properties_name:
+                item["name"] = f"{svc_type}-{item['name']}"
+            properties_name.append(item["name"])
+            result["properties"].append(item)
+
+        for act in svc.get("actions") or []:
+            if not isinstance(act, dict):
+                continue
+            aiid = act.get("iid")
+            if not isinstance(aiid, int):
+                continue
+            zh_cn = _lookup_i18n(
+                i18n,
+                f"service:{siid:03d}:action:{aiid:03d}",
+            )
+            act_item = {
+                "name": str(act.get("type") or ""),
+                "description": f"{act.get('description') or ''} / {zh_cn}".rstrip(
+                    " / "
+                ),
+                "method": {"siid": siid, "aiid": aiid},
+            }
+            if act_item["name"] in actions_name:
+                act_item["name"] = f"{svc_type}-{act_item['name']}"
+            actions_name.append(act_item["name"])
+            result["actions"].append(act_item)
+
+    return result
 
 
 def main() -> None:
@@ -25,7 +182,7 @@ def main() -> None:
         raise SystemExit(2)
 
     try:
-        spec = get_device_info(model, cache_path=cache_dir)
+        spec = fetch_device_spec(model)
         if (
             not isinstance(spec, dict)
             or not isinstance(spec.get("properties"), list)
@@ -34,8 +191,12 @@ def main() -> None:
             raise ValueError("设备规格结构异常")
 
         cache_path = cache_dir / f"{model}.json"
-        if cache_path.is_symlink() or not cache_path.is_file():
+        if cache_path.is_symlink():
             raise ValueError("设备规格缓存文件类型异常")
+        cache_path.write_text(
+            json.dumps(spec, ensure_ascii=False),
+            encoding="utf-8",
+        )
         with cache_path.open("r", encoding="utf-8") as file:
             persisted = json.load(file)
         if persisted != spec:

--- a/main.py
+++ b/main.py
@@ -105,7 +105,7 @@ READONLY_ALLOWED_CATEGORIES = {
 }
 
 
-@register(PLUGIN_NAME, "Ryan", "米家云端智能管家", "8.1.1")
+@register(PLUGIN_NAME, "Ryan", "米家云端智能管家", "8.1.2")
 class MiHomeControlPlugin(Star):
     def __init__(self, context: Context, config: AstrBotConfig = None):
         super().__init__(context)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,7 +4,7 @@ desc: AstrBot 的米家云端智能管家插件
 short_desc: 在 AstrBot 内安全管理米家设备、场景与白名单控制。
 help: |
   发送 /米家帮助 查看完整指令总览；发送 /米家帮助 [设备别名] 查看设备专属控制示例。
-version: v8.1.1
+version: v8.1.2
 astrbot_version: ">=4.24.2"
 author: RyanVaderAn
 repo: https://github.com/674537331/astrbot_plugin_mihome

--- a/mihome_client.py
+++ b/mihome_client.py
@@ -691,17 +691,28 @@ class MiHomeClient:
             and str(item.get("did", "")).strip() == target_did
         ]
         if not matches:
-            get_shared_devices = getattr(
-                self.api,
-                "get_shared_devices_list",
-                None,
-            )
-            if callable(get_shared_devices):
-                shared_devices = get_shared_devices()
-                if not isinstance(shared_devices, list):
-                    shared_devices = []
-                matches = [
-                    item
+            shared_devices = []
+            try:
+                get_shared_devices = getattr(
+                    self.api,
+                    "get_shared_devices_list",
+                    None,
+                )
+                if callable(get_shared_devices):
+                    shared_devices = get_shared_devices()
+            except Exception as e:
+                # 上游共享列表接口对部分账号会返回缺失 key 的响应
+                # （如 KeyError: 'list'）。这里与 get_devices() 保持一致的
+                # 容错策略：记录日志并视为无共享设备，避免只读状态整条链路
+                # 被一个共享列表异常打断。
+                logger.warning(
+                    f"[MiHome] 共享设备列表获取异常: {type(e).__name__}"
+                )
+                shared_devices = []
+            if not isinstance(shared_devices, list):
+                shared_devices = []
+            matches = [
+                item
                     for item in shared_devices
                     if isinstance(item, dict)
                     and str(item.get("did", "")).strip() == target_did
@@ -726,7 +737,16 @@ class MiHomeClient:
         for prop in spec.get("properties", []):
             if not isinstance(prop, dict) or not prop.get("name"):
                 continue
-            prop_obj = DevProp(prop)
+            try:
+                prop_obj = DevProp(prop)
+            except (KeyError, TypeError, ValueError) as e:
+                # 个别型号的规格可能缺少 rw/method 等字段或带未知类型，
+                # 单独跳过该属性即可，不应让整台设备的只读状态崩溃。
+                logger.debug(
+                    f"[MiHome] 跳过异常属性 {prop.get('name')!r}: "
+                    f"{type(e).__name__}"
+                )
+                continue
             base_name = str(prop["name"])
             prop_name = base_name
             if prop_name in device.prop_list:
@@ -746,7 +766,14 @@ class MiHomeClient:
         for action in spec.get("actions", []):
             if not isinstance(action, dict) or not action.get("name"):
                 continue
-            action_obj = DevAction(action)
+            try:
+                action_obj = DevAction(action)
+            except (KeyError, TypeError, ValueError) as e:
+                logger.debug(
+                    f"[MiHome] 跳过异常动作 {action.get('name')!r}: "
+                    f"{type(e).__name__}"
+                )
+                continue
             base_name = str(action["name"])
             action_name = base_name
             if action_name in device.action_list:
@@ -1432,10 +1459,25 @@ class MiHomeClient:
             return {"__error__": "请求超时 (设备离线或深度休眠)"}
         except DeviceGetError:
             return {"__error__": "设备拒绝读取能力菜单"}
+        except DeviceNotFoundError:
+            return {
+                "__error__": (
+                    "设备未在米家云端设备列表中找到，请先在米家管理中"
+                    "重新同步设备并核对别名与 DID 配置"
+                )
+            }
         except LoginError:
             return {"__error__": "鉴权失效"}
         except json.JSONDecodeError:
             return {"__error__": "米家云端没有返回有效数据，请稍后重试"}
+        except KeyError:
+            # 上游对部分型号/接口会返回缺少 key 的响应（如 'code'、'list'），
+            # 显式给出可理解的诊断，而不是暴露原始异常名。
+            return {
+                "__error__": (
+                    "云端响应结构异常（KeyError），接口返回不完整，请稍后重试"
+                )
+            }
         except Exception as e:
             return {"__error__": f"接口异常:{type(e).__name__}"}
 
@@ -1583,10 +1625,23 @@ class MiHomeClient:
             return {"__error__": "请求超时 (设备离线或深度休眠)"}
         except DeviceGetError:
             return {"__error__": "设备拒绝读取状态"}
+        except DeviceNotFoundError:
+            return {
+                "__error__": (
+                    "设备未在米家云端设备列表中找到，请先在米家管理中"
+                    "重新同步设备并核对别名与 DID 配置"
+                )
+            }
         except LoginError:
             return {"__error__": "鉴权失效"}
         except json.JSONDecodeError:
             return {"__error__": "米家云端没有返回有效数据，请稍后重试"}
+        except KeyError:
+            return {
+                "__error__": (
+                    "云端响应结构异常（KeyError），接口返回不完整，请稍后重试"
+                )
+            }
         except Exception as e:
             return {"__error__": f"接口异常:{type(e).__name__}"}
 

--- a/tests/test_control_tools.py
+++ b/tests/test_control_tools.py
@@ -48,17 +48,27 @@ def _install_stubs():
 
     class _DevProp:
         def __init__(self, data):
-            self.description = data.get("description", "")
-            self.rw = data.get("rw", "")
-            self.type = data.get("type", "")
-            self.range = data.get("range")
-            self.value_list = data.get("value-list")
-            self.method = data.get("method", {})
+            # 与 mijiaAPI 4.1.3 DevProp 保持一致的严格取键行为，
+            # 以覆盖插件对缺失字段属性的跳过逻辑。
+            self.name = data["name"]
+            self.desc = data["description"]
+            self.type = data["type"]
+            if self.type not in ["bool", "int", "uint", "float", "string"]:
+                raise ValueError(
+                    f"不支持的类型: {self.type}, 可选类型: "
+                    "bool, int, uint, float, string"
+                )
+            self.rw = data["rw"]
+            self.range = data["range"]
+            self.value_list = data.get("value-list", None)
+            self.method = data["method"]
 
     class _DevAction:
         def __init__(self, data):
-            self.description = data.get("description", "")
-            self.method = data.get("method", {})
+            # 与 mijiaAPI 4.1.3 DevAction 保持一致的严格取键行为。
+            self.name = data["name"]
+            self.desc = data["description"]
+            self.method = data["method"]
 
     mijia.mijiaAPI = _API
     mijia.mijiaDevice = _Device
@@ -707,6 +717,92 @@ class ClientCompatibilityTests(unittest.TestCase):
         self.assertIs(refreshed.api, client.api)
         self.assertIsNot(refreshed.api, previous_api)
         client.api.get_devices_list.assert_called_once_with()
+
+    def test_shared_list_key_error_degrades_to_device_not_found(self):
+        # 上游共享列表接口对部分账号返回缺少 key 的响应（KeyError: 'list'），
+        # 只读状态准备阶段应容错而不是把 KeyError 抛给调用方。
+        client = object.__new__(client_module.MiHomeClient)
+        client.api = types.SimpleNamespace(
+            get_devices_list=MagicMock(return_value=[]),
+            get_shared_devices_list=MagicMock(side_effect=KeyError("list")),
+        )
+        client._load_or_fetch_device_spec = MagicMock()
+
+        with self.assertRaises(client_module.DeviceNotFoundError):
+            client._prepare_device_sync("shared-did")
+
+        client.api.get_devices_list.assert_called_once_with()
+        client.api.get_shared_devices_list.assert_called_once_with()
+        client._load_or_fetch_device_spec.assert_not_called()
+
+    def test_shared_list_network_error_degrades_to_device_not_found(self):
+        client = object.__new__(client_module.MiHomeClient)
+        client.api = types.SimpleNamespace(
+            get_devices_list=MagicMock(return_value=[]),
+            get_shared_devices_list=MagicMock(
+                side_effect=client_module.RequestsTimeout("offline")
+            ),
+        )
+        client._load_or_fetch_device_spec = MagicMock()
+
+        with self.assertRaises(client_module.DeviceNotFoundError):
+            client._prepare_device_sync("shared-did")
+
+        client.api.get_shared_devices_list.assert_called_once_with()
+
+    def test_malformed_spec_property_is_skipped_not_fatal(self):
+        # 个别型号规格属性缺少 rw/method 等字段或带未知类型，
+        # 应跳过该属性而不是让整台设备的状态读取崩溃。
+        client = object.__new__(client_module.MiHomeClient)
+        client.api = types.SimpleNamespace(
+            get_devices_list=MagicMock(
+                return_value=[
+                    {
+                        "did": "did-1",
+                        "name": "异常设备",
+                        "model": "example.odd.v1",
+                    }
+                ]
+            )
+        )
+        client._load_or_fetch_device_spec = MagicMock(
+            return_value={
+                "name": "异常设备",
+                "properties": [
+                    {
+                        "name": "on",
+                        "description": "开关",
+                        "type": "bool",
+                        "rw": "rw",
+                        "range": None,
+                        "value-list": None,
+                        "method": {"siid": 2, "piid": 1},
+                    },
+                    {
+                        "name": "broken",
+                        # 缺少 description/type/rw/range/method，DevProp 应被跳过
+                    },
+                ],
+                "actions": [
+                    {
+                        "name": "toggle",
+                        "description": "切换",
+                        "method": {"siid": 2, "aiid": 1},
+                    },
+                    {
+                        "name": "broken-action",
+                        # 缺少 method，DevAction 应被跳过
+                    },
+                ],
+            }
+        )
+
+        device = client._prepare_device_sync("did-1")
+
+        self.assertIn("on", device.prop_list)
+        self.assertNotIn("broken", device.prop_list)
+        self.assertIn("toggle", device.action_list)
+        self.assertNotIn("broken-action", device.action_list)
 
 
 class DataManagerCredentialTests(unittest.TestCase):
@@ -1628,6 +1724,49 @@ class ClientCloudResultTests(unittest.IsolatedAsyncioTestCase):
             client.api.run_action.call_args.args[0]["aiid"],
             1,
         )
+
+    async def test_key_error_from_upstream_becomes_clear_diagnostic(self):
+        # 上游对部分型号/接口会返回缺少 key 的响应并抛出 KeyError；
+        # 插件不应把“接口异常:KeyError”直接暴露给用户。
+        client = object.__new__(client_module.MiHomeClient)
+        client._login_status = client_module.LOGIN_IDLE
+        client._api_lock = asyncio.Lock()
+        client.data_manager = MagicMock()
+        client.data_manager.auth_exists.return_value = True
+        client.api = types.SimpleNamespace()
+        client._prepare_device_sync = MagicMock(side_effect=KeyError("code"))
+
+        capabilities = await client.get_device_capabilities("did")
+        status = await client.get_device_props("did", ["temperature"])
+
+        expected = {
+            "__error__": "云端响应结构异常（KeyError），接口返回不完整，请稍后重试"
+        }
+        self.assertEqual(capabilities, expected)
+        self.assertEqual(status, expected)
+
+    async def test_device_not_found_becomes_clear_diagnostic(self):
+        client = object.__new__(client_module.MiHomeClient)
+        client._login_status = client_module.LOGIN_IDLE
+        client._api_lock = asyncio.Lock()
+        client.data_manager = MagicMock()
+        client.data_manager.auth_exists.return_value = True
+        client.api = types.SimpleNamespace()
+        client._prepare_device_sync = MagicMock(
+            side_effect=client_module.DeviceNotFoundError("gone")
+        )
+
+        capabilities = await client.get_device_capabilities("did")
+        status = await client.get_device_props("did", ["temperature"])
+
+        expected = {
+            "__error__": (
+                "设备未在米家云端设备列表中找到，请先在米家管理中"
+                "重新同步设备并核对别名与 DID 配置"
+            )
+        }
+        self.assertEqual(capabilities, expected)
+        self.assertEqual(status, expected)
 
     async def test_shared_device_capabilities_use_shared_directory_fallback(self):
         client = object.__new__(client_module.MiHomeClient)

--- a/tests/test_spec_worker.py
+++ b/tests/test_spec_worker.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_worker():
+    spec = importlib.util.spec_from_file_location(
+        "_mihome_spec_worker_test",
+        ROOT / "_spec_worker.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _page(i18n):
+    content = {
+        "props": {
+            "product": {"name": "Yeelight LED 灯丝灯", "model": "yeelink.light.mono5"},
+            "i18n": i18n,
+            "tree": {
+                "services": [
+                    {
+                        "iid": 2,
+                        "type": "urn:miot-spec-v2:service:light:00007802:yeelink",
+                        "properties": [
+                            {
+                                "iid": 1,
+                                "type": "on",
+                                "description": "Switch Status",
+                                "format": "bool",
+                                "access": ["read", "write"],
+                                "valueRange": None,
+                            },
+                            {
+                                "iid": 2,
+                                "type": "brightness",
+                                "description": "Brightness",
+                                "format": "uint8",
+                                "access": ["read", "write"],
+                                "valueRange": [1, 100, 1],
+                            },
+                        ],
+                        "actions": [
+                            {
+                                "iid": 1,
+                                "type": "toggle",
+                                "description": "Toggle",
+                            }
+                        ],
+                    }
+                ]
+            },
+        }
+    }
+    return (
+        '<!doctype html><html><head></head><body>'
+        '<script data-page="app" type="application/json">'
+        + json.dumps(content)
+        + "</script></body></html>"
+    )
+
+
+class SpecWorkerI18nFallbackTests(unittest.TestCase):
+    def setUp(self):
+        self.worker = _load_worker()
+
+    def _fetch(self, page):
+        fake_response = types.SimpleNamespace(status_code=200, text=page)
+        with patch.object(
+            self.worker.requests,
+            "get",
+            return_value=fake_response,
+        ) as mocked_get:
+            spec = self.worker.fetch_device_spec("yeelink.light.mono5")
+        self.assertEqual(
+            mocked_get.call_args.args[0],
+            "https://home.miot-spec.com/spec/yeelink.light.mono5",
+        )
+        return spec
+
+    def test_en_only_i18n_is_tolerated(self):
+        # issue #17：yeelink.light.mono5 的 i18n 只有 en，上游 get_device_info
+        # 硬取 zh_cn 抛 KeyError。worker 应回退到 en 并正常解析。
+        i18n = {
+            "en": {
+                "service:002:property:001": "Switch Status",
+                "service:002:property:002": "Brightness",
+                "service:002:action:001": "Toggle",
+            }
+        }
+        spec = self._fetch(_page(i18n))
+
+        self.assertEqual(spec["model"], "yeelink.light.mono5")
+        self.assertEqual(len(spec["properties"]), 2)
+        self.assertEqual(spec["properties"][0]["name"], "on")
+        self.assertEqual(spec["properties"][0]["rw"], "rw")
+        self.assertEqual(spec["properties"][0]["method"], {"siid": 2, "piid": 1})
+        self.assertIn("Switch Status", spec["properties"][0]["description"])
+        self.assertEqual(spec["properties"][1]["type"], "uint")
+        self.assertEqual(spec["properties"][1]["range"], [1, 100, 1])
+        self.assertEqual(len(spec["actions"]), 1)
+        self.assertEqual(spec["actions"][0]["name"], "toggle")
+        self.assertEqual(spec["actions"][0]["method"], {"siid": 2, "aiid": 1})
+
+    def test_missing_i18n_is_tolerated(self):
+        spec = self._fetch(_page({}))
+        self.assertEqual(len(spec["properties"]), 2)
+        # 无 zh/en 时保留原始英文描述，不附加分隔符
+        self.assertEqual(spec["properties"][0]["description"], "Switch Status")
+
+    def test_zh_cn_is_preferred_over_en(self):
+        i18n = {
+            "zh_cn": {
+                "service:002:property:001": "开关状态",
+            },
+            "en": {
+                "service:002:property:001": "Switch Status",
+            },
+        }
+        spec = self._fetch(_page(i18n))
+        self.assertIn("开关状态", spec["properties"][0]["description"])
+
+    def test_http_error_raises_value_error(self):
+        fake_response = types.SimpleNamespace(status_code=404, text="not found")
+        with patch.object(
+            self.worker.requests,
+            "get",
+            return_value=fake_response,
+        ):
+            with self.assertRaises(ValueError):
+                self.worker.fetch_device_spec("yeelink.light.mono5")
+
+    def test_main_writes_validated_cache_file(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_dir = Path(temp_dir)
+            with patch.object(
+                self.worker.requests,
+                "get",
+                return_value=types.SimpleNamespace(
+                    status_code=200,
+                    text=_page({"en": {}}),
+                ),
+            ):
+                with patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "_spec_worker.py",
+                        "yeelink.light.mono5",
+                        temp_dir,
+                    ],
+                ):
+                    self.worker.main()
+
+            cache_path = cache_dir / "yeelink.light.mono5.json"
+            self.assertTrue(cache_path.is_file())
+            persisted = json.loads(cache_path.read_text(encoding="utf-8"))
+            self.assertEqual(persisted["model"], "yeelink.light.mono5")
+            self.assertEqual(len(persisted["properties"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景
修复 #17：v8.1.0 起三台设备只读状态异常（KeyError × 2 + MiHomeClientError × 1）：
- 床头灯 `lemesh.light.wy0c02`（KeyError，在线）
- 音箱 `xiaomi.wifispeaker.l7a`（KeyError，在线）
- 窗帘 `yeelink.light.mono5`（MiHomeClientError，显示离线但实际在线）

## 变更
- `_spec_worker.py`：改用独立解析并回退 i18n 语言表（zh_cn -> en -> 空），修复 `yeelink.light.mono5` 等型号因缺少 zh_cn 文案导致规格拉取失败、只读状态报 MiHomeClientError。
- `_prepare_device_sync`：共享设备列表兜底加异常保护，DevProp/DevAction 构造容错跳过异常属性/动作，避免 KeyError 打断只读状态。
- `get_device_capabilities`/`get_device_props`：KeyError 与 DeviceNotFoundError 输出明确诊断文案，不再暴露原始异常名。
- 新增 spec worker 与客户端容错测试；版本升至 v8.1.2 并更新 CHANGELOG。

## 验证
- `pytest tests`：125 passed, 5 subtests passed。
- 实机：当前账号云端可访问的设备（xiaomi.wifispeaker.oh2p）经修复后的只读链路读取正常；issue 三台设备不在当前登录账号的家庭/共享列表中，需在米家管理中同步/核对 DID 后复查。